### PR TITLE
Added user guide for TL-WR940N  in english

### DIFF
--- a/pages/help.en.mdx
+++ b/pages/help.en.mdx
@@ -9,6 +9,7 @@ students contact us for. Please read through this page before getting in touch w
 
 To help you set up your router, we provide a video guide:
 [Setup Router with LRZ IP-Sheet - Olynet](https://youtu.be/cfi3lpi6sKQ)
+
 Alternatively (e.g. if your current bandwidth doesn't allow watching video) you can use this [manual](https://github.com/OlyNet/wiki/files/11137519/TL-WR940N.Config_eng.pdf)
 
 

--- a/pages/help.en.mdx
+++ b/pages/help.en.mdx
@@ -9,6 +9,8 @@ students contact us for. Please read through this page before getting in touch w
 
 To help you set up your router, we provide a video guide:
 [Setup Router with LRZ IP-Sheet - Olynet](https://youtu.be/cfi3lpi6sKQ)
+Alternatively (e.g. if your current bandwidth doesn't allow watching video) you can use this [manual](https://github.com/OlyNet/wiki/files/11137519/TL-WR940N.Config_eng.pdf)
+
 
 If you are using a Studentenstadt-Router (StuStaNet), you might find this [sheet](https://github.com/OlyNet/wiki/files/11081376/StuStaNet.pdf) helpfull.
 


### PR DESCRIPTION
Please add a a paragraph between the video link and the manual. In the preview it didn't show that there is no gap. In the german version it's there